### PR TITLE
Add changelog page

### DIFF
--- a/assets/_custom.scss
+++ b/assets/_custom.scss
@@ -11,6 +11,10 @@ body {
     line-height: 1.2;
 }
 
+.markdown li {
+    margin-bottom: 7px;
+}
+
 // TODO: fix dark theme
 @media (prefers-color-scheme: dark) {
     body {
@@ -23,4 +27,27 @@ body {
 h2.book-brand span {
     position: relative;
     top: 2px;
+}
+
+.bitrise-stack-chip {
+    text-transform: uppercase;
+    font-size: 11px;
+    border-radius: 5px;
+    padding: 3px 7px;
+    font-weight: bold;
+}
+
+.bitrise-stack-chip.green {
+    color: #167231;
+    background: #EEF9F1;
+}
+
+.bitrise-stack-chip.blue {
+    color: #1066AC;
+    background: #ECF8FD;
+}
+
+.bitrise-stack-chip.neutral {
+    color: #6B6071;
+    background: #F6F4F6;
 }

--- a/content/changelogs/Xcode stacks.md
+++ b/content/changelogs/Xcode stacks.md
@@ -1,0 +1,41 @@
+---
+title: Xcode stacks changelog
+---
+
+Bitrise stacks are updated continuously according to the [stack update policy](https://devcenter.bitrise.io/en/infrastructure/build-stacks/stack-update-policy.html). This page is updated every time a new update is released to one of the [macOS-based Xcode stacks](/platform/macos).
+
+When a specific Xcode version is not mentioned, all actively updated Xcode stacks are affected.
+
+## Updates
+
+### Stack update `v2023-07-12`
+
+- {{< chip text="edge" >}} [Xcode 15 Beta 4](https://developer.apple.com/documentation/xcode-release-notes/xcode-15-release-notes) is available, replacing Beta 3.
+- {{< chip text="edge" >}} {{< chip text="stable" >}} Some iOS simulator devices are pre-warmed for better performance. For each iOS runtime, the device `Bitrise iOS default` is already booted once (then shut down) so that the next boot during testing is faster and uses less CPU.
+- {{< chip text="stable" >}} [Tuist](https://tuist.io) has been updated to version 3.19.
+
+### Stack update `v2023-07-06`
+
+This update is for {{< chip text="edge" >}} stacks {{< chip text="Xcode 14.3" >}} and {{< chip text="Xcode 15" >}} only.
+
+- [Xcode 15 Beta 3](https://developer.apple.com/documentation/xcode-release-notes/xcode-15-release-notes) is available, replacing Beta 2.
+- Tuist has been updated to [version 3.20](https://github.com/tuist/tuist/releases/tag/3.20.0)
+- The following simulator runtimes are now installed:
+  - iOS 16.4
+  - tvOS 16.4
+  - watchOS 9.4
+
+### Stack update `v2023-07-03`
+
+- {{< chip text="stable" >}} {{< chip text="Xcode 14.0-14.3" >}} Default Ruby version has changed from 2.7.6 to 3.2.2 according to the [deprecation plan](https://discuss.bitrise.io/t/ruby-2-7-x-deprecation/22544).
+
+### Stack update `v2023-06-22`
+
+- {{< chip text="stable" >}} {{< chip text="edge" >}} Ruby versions are now managed via [asdf](https://asdf-vm.com/). During the transition period, both `rbenv` and `asdf` are installed and can be used, but we recommend migrating to `asdf`, which also manages Node.js and Go versions on the stacks.
+- {{< chip text="edge" >}} Default Ruby version has changed from 2.7.6 to 3.2.2 according to the [deprecation plan](https://discuss.bitrise.io/t/ruby-2-7-x-deprecation/22544).
+- {{< chip text="stable" >}} {{< chip text="edge" >}} Each installed iOS simulator runtime now has a device named `Bitrise iOS default`. This name is constant across all runtime versions, but the real device type changes based on the iOS version. You can use this device name in test steps and destination specifiers and be sure that it’s going to be available across all Xcode and runtime versions.
+- {{< chip text="stable" >}} {{< chip text="edge" >}} The `cmake;3.10.2.4988404` Android SDK package is now preinstalled
+- {{< chip text="stable" >}} {{< chip text="edge" >}} [OpenUPM CLI](https://openupm.com/) is now preinstalled
+- {{< chip text="edge" >}} [swift-format](https://github.com/apple/swift-format) is now preinstalled
+
+

--- a/layouts/changelogs/list.html
+++ b/layouts/changelogs/list.html
@@ -1,0 +1,22 @@
+{{ define "main" }}
+  {{ range sort .Paginator.Pages }}
+  <article class="markdown book-post">
+    <h2>
+      <a href="{{ .RelPermalink }}">{{ partial "docs/title.html" . }}</a>
+    </h2>
+    {{ partial "docs/post-meta" . }}
+    <p>
+      {{- .Summary -}}
+      {{ if .Truncated }}
+        <a href="{{ .RelPermalink }}">...</a>
+      {{ end }}
+    </p>
+  </article>
+  {{ end }}
+
+  {{ template "_internal/pagination.html" . }}
+{{ end }}
+
+{{ define "toc" }}
+  {{ partial "docs/taxonomy" . }}
+{{ end }}

--- a/layouts/changelogs/single.html
+++ b/layouts/changelogs/single.html
@@ -1,0 +1,13 @@
+{{ define "main" }}
+<article class="markdown">
+  <h1>
+    <a href="{{ .RelPermalink }}">{{ partial "docs/title.html" . }}</a>
+  </h1>
+  {{ partial "docs/post-meta" . }}
+  {{- .Content -}}
+</article>
+{{ end }}
+
+{{ define "toc" }}
+  {{ partial "docs/toc" . }}
+{{ end }}

--- a/layouts/shortcodes/chip.html
+++ b/layouts/shortcodes/chip.html
@@ -1,0 +1,10 @@
+{{ $text := .Get "text" }}
+{{ $colorTag := "" }}
+{{ if eq $text "edge" }}
+    {{ $colorTag = "blue" }}
+{{ else if eq $text "stable"}}
+    {{ $colorTag = "green" }}
+{{ else }}
+    {{ $colorTag = "neutral" }}
+{{ end }}
+<span class="bitrise-stack-chip {{ $colorTag }}">{{ $text }}</span>


### PR DESCRIPTION
- Add a new content type for changelog pages (this PR only adds the macOS page, Linux is coming soon)
- Add a custom shortcode for inline chips that I'm using for labeling stable/edge changelog entries


### Preview
<img width="788" alt="image" src="https://github.com/bitrise-io/stacks/assets/1694986/8296e7cf-edf1-4cff-9162-9651be0cafcd">
